### PR TITLE
Included canceled builds in the failed build percentage

### DIFF
--- a/src/getStats.js
+++ b/src/getStats.js
@@ -47,7 +47,7 @@ const totalBuildTime = builds => (
 const isSuccessfulDeployment = build => (
   build.build_parameters &&
   build.build_parameters.PRODUCTION &&
-  build.status !== 'failed'
+  build.status !== 'failed' && build.status !== 'canceled'
 );
 
 module.exports = (fetchBatch, fromDate) => (

--- a/src/getStats.js
+++ b/src/getStats.js
@@ -37,7 +37,7 @@ const getCodeDeploymentCount = builds => (
 );
 
 const failedBuilds = builds => (
-  builds.filter(build => build.status === 'failed')
+  builds.filter(({ status }) => status === 'failed' || status === 'canceled')
 );
 
 const totalBuildTime = builds => (

--- a/src/index.js
+++ b/src/index.js
@@ -25,10 +25,8 @@ const circleCIFetchBatch = (offset) => {
 }
 
 const formatTime = millis => {
-  const seconds = (millis / 1000) % 60;
-  const minutes = (millis / (1000 * 60)) % 60;
-
-  return `${Math.floor(minutes)}:${Math.floor(seconds)}`
+  const d = new Date(millis);
+  return `${d.getUTCMinutes()}:${('0' + d.getUTCSeconds()).slice(-2)}`
 }
 
 const sendToSlack = weekAgo => stats => {

--- a/test/getStats.js
+++ b/test/getStats.js
@@ -85,7 +85,7 @@ describe('getStats', () => {
             },
             {
               'start_time': '2017-03-02T10:18:33.094Z',
-              'status': 'failed',
+              'status': 'canceled',
               'build_time_millis': 10,
             },
             {

--- a/test/getStats.js
+++ b/test/getStats.js
@@ -87,6 +87,7 @@ describe('getStats', () => {
               'start_time': '2017-03-02T10:18:33.094Z',
               'status': 'canceled',
               'build_time_millis': 10,
+              'build_parameters': { 'PRODUCTION': 'true' },
             },
             {
               'start_time': '2017-03-02T10:18:33.094Z',


### PR DESCRIPTION
Fixes #3 by including `canceled` builds in the failed build percentage. 
I excluded `canceled` builds from the successful deployments count to match with the existing `failed` check